### PR TITLE
Swap to expecting querystring mapping in image config.

### DIFF
--- a/src/js/libpannellum.js
+++ b/src/js/libpannellum.js
@@ -1196,8 +1196,8 @@ function Renderer(container) {
         TextureImageLoader.prototype.loadTexture = function(src, texture, callback) {
             this.texture = texture;
             this.callback = callback;
-            this.image.src = globalParams.imageSrcFormatter 
-                                ? globalParams.imageSrcFormatter(src)
+            this.image.src = globalParams.imageSrcFormatter
+                                ? globalParams.imageSrcFormatter(src, image)
                                 : src
         };
 


### PR DESCRIPTION
New approach:

1. A {key: query string} mapping is passed inside the multiRes config object.
2. A separate function is passed to turn image.src => key.

Advantages of this over previous approach (mapping in closure) is that you don't have to throw away the renderer and rebuild it/significantly modify libpannellum interfaces.