### PR TITLE
Also modify image paths on WebWorker based loader.

### DIFF
--- a/src/js/libpannellum.js
+++ b/src/js/libpannellum.js
@@ -1289,6 +1289,9 @@ function Renderer(container) {
         processNextTile = function(node) {
             // Since web worker is created from a Blob, we need the absolute URL
             var path = new URL(node.path + '.' + image.extension, window.location).href;
+            if (globalParams.imageSrcFormatter){
+                path = globalParams.imageSrcFormatter(path, image);
+            }
             texturesLoading[path] = node;
             worker.postMessage([path, globalParams.crossOrigin]);
         };


### PR DESCRIPTION
The latest versions of Pannellum, on which our fork is based, have sprouted an additional image loading path which I didn't notice, used in a subset of contemporary browsers. This applies the same transformation to the image src as seen in the ordinary path.